### PR TITLE
Bump ad-m/github-push-action from 0.6.0 to 0.8.0 (#144)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,13 +58,13 @@ jobs:
           mvn -B release:perform -Darguments=-DperformRelease -DperformRelease -Prelease -s maven-settings.xml
 
       - name: Push changes to ${{github.base_ref}}
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{github.base_ref}}
 
       - name: Push tags
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true


### PR DESCRIPTION
Backport of https://github.com/quarkiverse/quarkus-jackson-jq/pull/144

Bumps [ad-m/github-push-action](https://github.com/ad-m/github-push-action) from 0.6.0 to 0.8.0.
- [Release notes](https://github.com/ad-m/github-push-action/releases)
- [Commits](https://github.com/ad-m/github-push-action/compare/v0.6.0...v0.8.0)

---
updated-dependencies:
- dependency-name: ad-m/github-push-action dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 9a20d9e815414a429307be2e86ac8b793c50d9ae)