### PR TITLE
Upgrade jackson-jq to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.15.1</quarkus.version>
-    <jackson-jq.version>1.0.0-preview.20240207</jackson-jq.version>
+    <jackson-jq.version>1.0.0</jackson-jq.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Assuming this change is acceptable - any chance of having a new quarkus-jackson-jq release afterwards?