### PR TITLE
Upgrade to Quarkus 3.23 and adjust native tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,17 +41,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Get Date for cache key
-        id: get-date
-        run: echo "::set-output name=date::$(date -u '+%Y-%m')"
-        shell: bash
-
-      - name: Cache Maven Repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.OS }}-${{ steps.get-date.outputs.date }}
-
       - name: Maven formatter validate + JVM verify
         run: mvn -B formatter:validate verify --file pom.xml
 
@@ -72,17 +61,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-
-      - name: Get Date for cache key
-        id: get-date-native
-        run: echo "::set-output name=date::$(date -u '+%Y-%m')"
-        shell: bash
-
-      - name: Cache Maven Repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.OS }}-native-${{ steps.get-date-native.outputs.date }}
 
       - name: Maven formatter validate + Native verify
         # This will use <quarkus.native.container-build>true</quarkus.native.container-build>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - "main"
+      - main
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'
@@ -23,35 +23,74 @@ on:
       - '.all-contributorsrc'
 
 jobs:
-  build:
-
+  # ----------------------------------------------------------------------------
+  # 1) JVM build + tests under Java 17
+  # ----------------------------------------------------------------------------
+  build-jvm:
+    name: JVM Build & Tests (Java 17)
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '17'
-          distribution: 'graalvm'
-          components: 'native-image'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'maven'
 
-      - name: Get Date
+      - name: Get Date for cache key
         id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        run: echo "::set-output name=date::$(date -u '+%Y-%m')"
         shell: bash
+
       - name: Cache Maven Repository
-        id: cache-maven
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          # refresh cache every month to avoid unlimited growth
-          key: maven-repo-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+          key: maven-${{ runner.OS }}-${{ steps.get-date.outputs.date }}
 
-      - name: Build and Run Native with Maven
+      - name: Maven formatter validate + JVM verify
+        run: mvn -B formatter:validate verify --file pom.xml
+
+  # ----------------------------------------------------------------------------
+  # 2) Native build + integration‐tests (Java 21 + container)
+  # ----------------------------------------------------------------------------
+  build-native:
+    name: Native Build & Tests (Mandrel JDK 21 in container)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Get Date for cache key
+        id: get-date-native
+        run: echo "::set-output name=date::$(date -u '+%Y-%m')"
+        shell: bash
+
+      - name: Cache Maven Repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.OS }}-native-${{ steps.get-date-native.outputs.date }}
+
+      - name: Maven formatter validate + Native verify
+        # This will use <quarkus.native.container-build>true</quarkus.native.container-build>
+        # and <quarkus.native.builder-image>…jdk-21</…> as defined in the IT POM,
+        # so Quarkus spins up a Mandrel JDK21 container to produce the Linux binary,
+        # and then runs the integration tests against that native runner.
         run: mvn -B formatter:validate verify --file pom.xml -Pnative
+
+      - name: Cleanup Native Runner
+        if: always()
+        run: rm -f target/*-runner

--- a/.quarkus/cli/plugins/quarkus-cli-catalog.json
+++ b/.quarkus/cli/plugins/quarkus-cli-catalog.json
@@ -1,0 +1,5 @@
+{
+  "version" : "v1",
+  "lastUpdate" : "08/10/2024 15:54:13",
+  "plugins" : { }
+}

--- a/deployment/src/main/java/io/quarkiverse/jackson/jq/deployment/JacksonJqProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jackson/jq/deployment/JacksonJqProcessor.java
@@ -21,6 +21,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.runtime.RuntimeValue;
 import net.thisptr.jackson.jq.BuiltinFunction;
@@ -28,10 +29,30 @@ import net.thisptr.jackson.jq.Scope;
 
 class JacksonJqProcessor {
     private static final String FEATURE = "jackson-jq";
+    private static final String JACKSON_JQ_GROUP_ID = "net.thisptr";
+    private static final String JACKSON_JQ_ARTIFACT_ID = "jackson-jq";
+    private static final String JACKSON_JQ_EXTRA_ARTIFACT_ID = "jackson-jq-extra";
 
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    /**
+     * Ensure Quarkus indexes net.thisptr:jackson-jq at build time.
+     * This avoids “Reindexing … index version is 10” warnings.
+     */
+    @BuildStep
+    IndexDependencyBuildItem indexJacksonJq() {
+        return new IndexDependencyBuildItem(JACKSON_JQ_GROUP_ID, JACKSON_JQ_ARTIFACT_ID);
+    }
+
+    /**
+     * Likewise, index jackson-jq-extra.
+     */
+    @BuildStep
+    IndexDependencyBuildItem indexJacksonJqExtra() {
+        return new IndexDependencyBuildItem(JACKSON_JQ_GROUP_ID, JACKSON_JQ_EXTRA_ARTIFACT_ID);
     }
 
     @BuildStep
@@ -61,7 +82,7 @@ class JacksonJqProcessor {
                 recorder.addFunction(root, f.getName(), f.getFunction());
             }
         });
-        lookupFunctions(indexView, config, context, net.thisptr.jackson.jq.internal.BuiltinFunction.class).forEach(f -> {
+        lookupFunctions(indexView, config, context, net.thisptr.jackson.jq.BuiltinFunction.class).forEach(f -> {
             if (!excludes.contains(StringUtils.substringBefore(f.getName(), '/'))) {
                 recorder.addFunction(root, f.getName(), f.getFunction());
             }

--- a/deployment/src/main/java/io/quarkiverse/jackson/jq/deployment/JacksonJqSupport.java
+++ b/deployment/src/main/java/io/quarkiverse/jackson/jq/deployment/JacksonJqSupport.java
@@ -72,7 +72,7 @@ final class JacksonJqSupport {
         DotName f = DotName.createSimple(Function.class.getName());
         DotName a = DotName.createSimple(annotationType.getName());
 
-        for (ClassInfo ci : indexView.getAllKnownImplementors(f)) {
+        for (ClassInfo ci : indexView.getAllKnownImplementations(f)) {
             AnnotationInstance annotation = ci.declaredAnnotation(a);
             if (annotation == null) {
                 continue;

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -8,6 +8,13 @@
   </parent>
   <artifactId>quarkus-jackson-jq-integration-tests</artifactId>
   <name>Quarkus - Jackson Jq - Integration Tests</name>
+
+  <properties>
+    <quarkus.native.container-build>true</quarkus.native.container-build>
+    <!-- Using JDK 21 for the native builds checks since Netty has a bug on JDK 17: https://github.com/quarkusio/quarkus/issues/39819 -->
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21</quarkus.native.builder-image>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -53,7 +60,8 @@
         </property>
       </activation>
       <properties>
-        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.package.jar.enabled>false</quarkus.package.jar.enabled>
+        <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
       <build>
         <plugins>

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,2 +1,1 @@
-
 quarkus.jackson.jq.functions.excludes = min_by

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.16.3</quarkus.version>
+    <quarkus.version>3.23.2</quarkus.version>
     <jackson-jq.version>1.3.0</jackson-jq.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
In this PR:

1. Fixed deprecated warnings
2. Upgrade to Quarkus 3.23
3. Move native test to the JDK 21 container due to https://github.com/quarkusio/quarkus/issues/39819