### PR TITLE
Bump Mandrel native builder image to jdk-25

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -11,8 +11,9 @@
 
   <properties>
     <quarkus.native.container-build>true</quarkus.native.container-build>
-    <!-- Using JDK 21 for the native builds checks since Netty has a bug on JDK 17: https://github.com/quarkusio/quarkus/issues/39819 -->
-    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-21</quarkus.native.builder-image>
+    <!-- Mandrel's jdk-21 line is capped at 23.1.x (GraalVM 23), but Quarkus 3.38+ requires
+         GraalVM/Mandrel 25.0+ for native builds, which Mandrel only ships on JDK 25. -->
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel-builder-image:jdk-25</quarkus.native.builder-image>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.37.3</quarkus.version>
+    <quarkus.version>3.39.0</quarkus.version>
     <jackson-jq.version>1.6.2</jackson-jq.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Quarkus 3.38+ requires GraalVM/Mandrel 25.0+ for native builds. The jdk-21 Mandrel line is capped at 23.1.x, so the builder image needs to move to the jdk-25 line to satisfy the minimum version check.