### PR TITLE
Update current version to 2.6.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 2.5.2
+  current-version: 2.6.0
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
## Summary

Release 2.6.0 with dependency updates and Jandex 3.x support.

## Changes Since 2.5.2

### Dependency Updates

**Major:**
- ⬆️ **Quarkus**: 3.37.1 → **3.39.1** (+2 minor versions)
  - 3.37.1 → 3.37.2 (#335)
  - 3.37.2 → 3.37.3 (#336)
  - 3.37.3 → 3.39.0 (implied)
  - 3.39.0 → 3.39.1 (#346)

- ⭐ **jackson-jq**: 1.6.2 → **1.6.4** (#348, #350)
  - **Includes Jandex 3.x support!**
  - Eliminates Jandex reindexing warnings in Quarkus 3.x+ builds
  - Better build performance (no unnecessary reindexing)

**Build/Infrastructure:**
- ⬆️ maven-compiler-plugin: → 3.15.0 (#340)
- ⬆️ actions/setup-java: → v6 (#345)
- ⬆️ Mandrel native builder image: → jdk-25 (#344)

**New:**
- ✨ Added Renovate bot configuration (#339)

## 🎉 Key Highlight: Jandex 3.x Support

### Before (1.6.2 / 1.6.3)
```
[WARNING] [io.quarkus.deployment.index] Reindexing /path/to/jackson-jq-1.6.3.jar, 
at least Jandex 3.0 must be used to index an application dependency (index version is 10)
[WARNING] [io.quarkus.deployment.index] Reindexing /path/to/jackson-jq-extra-1.6.3.jar, 
at least Jandex 3.0 must be used to index an application dependency (index version is 10)
```

### After (1.6.4)
✅ **No warnings!** - Jandex 3.x indexes included in the JARs

## Benefits

- ✅ Eliminates Jandex reindexing warnings in Quarkus 3.x+
- ✅ Improves build performance
- ✅ Latest Quarkus 3.39.1 with bug fixes and improvements
- ✅ Future-proof for Quarkus 4.x

## Version Recommendation

**Release as 2.6.0** - includes minor Quarkus bumps and infrastructure improvements beyond just patches.