### PR TITLE
Upgrade jackson-jq to 1.6.4 with Jandex 3.x support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.39.1</quarkus.version>
-    <jackson-jq.version>1.6.3</jackson-jq.version>
+    <jackson-jq.version>1.6.4</jackson-jq.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
## Summary

Upgrades `net.thisptr:jackson-jq` from **1.6.3** to **1.6.4**.

## What's New in 1.6.4

⭐ **Jandex 3.x Support** via [eiiches/jackson-jq#549](https://github.com/eiiches/jackson-jq/pull/549)

This eliminates Jandex reindexing warnings in Quarkus 3.x+ builds.

## Before (1.6.3)

```
[WARNING] [io.quarkus.deployment.index] Reindexing /path/to/jackson-jq-1.6.3.jar, 
at least Jandex 3.0 must be used to index an application dependency (index version is 10)
[WARNING] [io.quarkus.deployment.index] Reindexing /path/to/jackson-jq-extra-1.6.3.jar, 
at least Jandex 3.0 must be used to index an application dependency (index version is 10)
```

## After (1.6.4)

✅ **No warnings!** - Jandex 3.x indexes included in the JARs

## Benefits

- ✅ Eliminates Jandex reindexing warnings in Quarkus 3.x+
- ✅ Improves build performance (no unnecessary reindexing at build time)
- ✅ Jandex 3.x compatible indexes out of the box
- ✅ Future-proof for Quarkus 4.x

## Testing

Build tested successfully:
```bash
mvn clean install -DskipTests
```

## Release Plan

After merge, release as **2.6.0** with:
- jackson-jq: 1.6.3 → 1.6.4
- Quarkus: 3.39.1 (already upgraded in main)